### PR TITLE
paste0 => file.path for comment_submission

### DIFF
--- a/R/submissions.R
+++ b/R/submissions.R
@@ -77,7 +77,7 @@ NULL
 #' \dontrun{comment_submission(1350207, 5681164, 4928217, "test")}
 comment_submission <- function(course_id, assignment_id, user_id, comm,
                              to_group = TRUE, visible = TRUE) {
-  url <- paste0(canvas_url(),
+  url <- file.path(canvas_url(),
                 paste("courses", course_id, "assignments", assignment_id,
                       "submissions", user_id, sep = "/"))
   args <- list(access_token = check_token(),


### PR DESCRIPTION
Changed `paste0` to `file.path` for `comment_submission` as was done for `grade_submission`. Without this change, I received an error when attempting to submit comments via `comment_submission`.